### PR TITLE
OnlTools/StJevpBuilders/fstBuilder update

### DIFF
--- a/OnlTools/Jevp/StJevpBuilders/fstBuilder.cxx
+++ b/OnlTools/Jevp/StJevpBuilders/fstBuilder.cxx
@@ -1401,6 +1401,11 @@ void fstBuilder::event(daqReader *rdr)
       }
     }   
   }
+  //set plotting range for time bin distributions
+  hEventSumContents.hMaxTimeBin_ZS->GetXaxis()->SetRangeUser(tb_plot_low, tb_plot_high);
+  hEventSumContents.hMaxTimeBin->GetXaxis()->SetRangeUser(tb_plot_low, tb_plot_high);
+  for(int index = 0; index < mTbVsAdcHist; index++) hTbVsAdcContents.tbVsAdcArray[index]->GetXaxis()->SetRangeUser(tb_plot_low, tb_plot_high);
+  for(int glbElecApvIdx = 0 ; glbElecApvIdx < totAPV ; glbElecApvIdx++) hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->GetXaxis()->SetRangeUser(tb_plot_low, tb_plot_high); 
 
   PCP;
 
@@ -2060,10 +2065,11 @@ void fstBuilder::stoprun(daqReader *rdr)
       }
     }
 
-    double entriesTB_123=0, entriesTB_all=0, fraction = 1.0;
-    if(hMaxTimeBinContents.maxTimeBinArray[j]->GetEntries()>0) {
-      entriesTB_123 = hMaxTimeBinContents.maxTimeBinArray[j]->Integral(2, numTb-1);
-      entriesTB_all = hMaxTimeBinContents.maxTimeBinArray[j]->Integral(1, numTb);
+    double entriesTB_123=0, entriesTB_all=0, fraction = 0.;
+    entriesTB_all = hMaxTimeBinContents.maxTimeBinArray[j]->Integral(1, numTb);
+    //if(hMaxTimeBinContents.maxTimeBinArray[j]->Integral(1, numTb)>0) {
+    if(entriesTB_all>0.) {
+      entriesTB_123 = hMaxTimeBinContents.maxTimeBinArray[j]->Integral((numTb%2==1)?(numTb/2+1):(numTb/2), (numTb%2==1)?(numTb/2+1):(numTb/2+1))/((numTb%2==1)?1:2);
       fraction = entriesTB_123/entriesTB_all;
       if(fraction<maxTbFracOK) {
 	//LOG(U_FST,"maxTimeBinFraction::section RDO%d_ARM%d_GROUP%d with fraction %f!", rdoIdx, armIdx, portIdx, fraction);
@@ -2123,13 +2129,14 @@ void fstBuilder::stoprun(daqReader *rdr)
     for(int armIdx=0; armIdx<ArmPerRdo; armIdx++){
       for(int refApvIdx=0; refApvIdx<ApvPerArm; refApvIdx++){
         int glbElecApvIdx = refApvIdx + armIdx*ApvPerArm + (rdoIdx-1)*ApvPerRdo;        // 0-287
-        double entriesTB_123=0, entriesTB_all=0, fraction = 1.0;
-        if(hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->GetEntries()>0){
-          entriesTB_123 = hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->Integral(2, numTb-1);
-          entriesTB_all = hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->Integral(1, numTb);
+        double entriesTB_123=0, entriesTB_all=0, fraction = 0.;
+        entriesTB_all = hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->Integral(1, numTb);
+        //if(hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->GetEntries()>0){
+        if(entriesTB_all>0.){
+          entriesTB_123 = hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->Integral((numTb%2==1)?(numTb/2+1):(numTb/2), (numTb%2==1)?(numTb/2+1):(numTb/2+1))/((numTb%2==1)?1:2);
           fraction = entriesTB_123/entriesTB_all;
 	}
-        hEventSumContents.hMaxTBfractionVsAPV_ZS->SetBinContent(glbElecApvIdx, fraction);
+        hEventSumContents.hMaxTBfractionVsAPV_ZS->SetBinContent(glbElecApvIdx+1, fraction);
       }
     }
   }

--- a/OnlTools/Jevp/StJevpBuilders/fstBuilder.cxx
+++ b/OnlTools/Jevp/StJevpBuilders/fstBuilder.cxx
@@ -1405,6 +1405,7 @@ void fstBuilder::event(daqReader *rdr)
   hEventSumContents.hMaxTimeBin_ZS->GetXaxis()->SetRangeUser(tb_plot_low, tb_plot_high);
   hEventSumContents.hMaxTimeBin->GetXaxis()->SetRangeUser(tb_plot_low, tb_plot_high);
   for(int index = 0; index < mTbVsAdcHist; index++) hTbVsAdcContents.tbVsAdcArray[index]->GetXaxis()->SetRangeUser(tb_plot_low, tb_plot_high);
+  for(int index = 0; index < mMaxTimeBinHist; index++) hMaxTimeBinContents.maxTimeBinArray[index]->GetXaxis()->SetRangeUser(tb_plot_low, tb_plot_high);
   for(int glbElecApvIdx = 0 ; glbElecApvIdx < totAPV ; glbElecApvIdx++) hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->GetXaxis()->SetRangeUser(tb_plot_low, tb_plot_high); 
 
   PCP;

--- a/OnlTools/Jevp/StJevpBuilders/fstBuilder.cxx
+++ b/OnlTools/Jevp/StJevpBuilders/fstBuilder.cxx
@@ -1357,7 +1357,7 @@ void fstBuilder::event(daqReader *rdr)
   }
 
   PCP;
-  numTb = numTimeBin;        		//default: 9 timebins
+  numTb = numTb_default;        		//default: 9 timebins
 
   //LOG("JEFF", "numbTB=%d", numTimeBin);
 
@@ -2069,7 +2069,7 @@ void fstBuilder::stoprun(daqReader *rdr)
     entriesTB_all = hMaxTimeBinContents.maxTimeBinArray[j]->Integral(1, numTb);
     //if(hMaxTimeBinContents.maxTimeBinArray[j]->Integral(1, numTb)>0) {
     if(entriesTB_all>0.) {
-      entriesTB_123 = hMaxTimeBinContents.maxTimeBinArray[j]->Integral((numTb%2==1)?(numTb/2+1):(numTb/2), (numTb%2==1)?(numTb/2+1):(numTb/2+1))/((numTb%2==1)?1:2);
+      entriesTB_123 = hMaxTimeBinContents.maxTimeBinArray[j]->Integral(numTb/2+1, numTb/2+1);
       fraction = entriesTB_123/entriesTB_all;
       if(fraction<maxTbFracOK) {
 	//LOG(U_FST,"maxTimeBinFraction::section RDO%d_ARM%d_GROUP%d with fraction %f!", rdoIdx, armIdx, portIdx, fraction);
@@ -2133,7 +2133,7 @@ void fstBuilder::stoprun(daqReader *rdr)
         entriesTB_all = hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->Integral(1, numTb);
         //if(hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->GetEntries()>0){
         if(entriesTB_all>0.){
-          entriesTB_123 = hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->Integral((numTb%2==1)?(numTb/2+1):(numTb/2), (numTb%2==1)?(numTb/2+1):(numTb/2+1))/((numTb%2==1)?1:2);
+          entriesTB_123 = hMaxTimeBinContents_APV.maxTimeBinArray_APV[glbElecApvIdx]->Integral(numTb/2+1,numTb/2+1);
           fraction = entriesTB_123/entriesTB_all;
 	}
         hEventSumContents.hMaxTBfractionVsAPV_ZS->SetBinContent(glbElecApvIdx+1, fraction);

--- a/OnlTools/Jevp/StJevpBuilders/fstBuilder.h
+++ b/OnlTools/Jevp/StJevpBuilders/fstBuilder.h
@@ -90,7 +90,6 @@ class fstBuilder : public JevpBuilder {
   static const int ApvNumOffset = 12;    // APV RO number same as IST | used for APV number convertion
   static const int ApvRoPerPort = 12;    // APV RO number same as IST
   static const int ApvRoPerArm  = 24;    // APV RO number same as IST
-
   static const int numTimeBin   = 9;     // to be decided
   static const int goodChCut    = 64;    // to be decided
   static const int minPedVal    = 200;   // to be decided
@@ -129,6 +128,10 @@ class fstBuilder : public JevpBuilder {
   static const float rStop[RstripPerMod];
   static const float rDelta;
 
+  //Time Bin plots plot range
+  const float tb_plot_low  = 3.0;
+  const float tb_plot_high = 6.0;
+
   //FST mapping
   int fstGeomMapping[totCh]; //FST channel mapping (electronics ID to geometry ID transform)
   int fstElecMapping[totCh]; //FST channel mapping (geometry ID & electronics ID transform)
@@ -137,7 +140,7 @@ class fstBuilder : public JevpBuilder {
   float fstPedestal[numTimeBin][totCh];
   float fstRmsNoise[numTimeBin][totCh];
   float fstRanNoise[numTimeBin][totCh];
-
+  
   //*** Histogram Declarations...
   union {
     TH2 *adcArray[1]; //ADC value of each module's channels (ADC value vs. channel index)

--- a/OnlTools/Jevp/StJevpBuilders/fstBuilder.h
+++ b/OnlTools/Jevp/StJevpBuilders/fstBuilder.h
@@ -129,8 +129,8 @@ class fstBuilder : public JevpBuilder {
   static const float rDelta;
 
   //Time Bin plots plot range
-  const float tb_plot_low  = 3.0;
-  const float tb_plot_high = 6.0;
+  const float tb_plot_low  = 0.;
+  const float tb_plot_high = 3.;
 
   //FST mapping
   int fstGeomMapping[totCh]; //FST channel mapping (electronics ID to geometry ID transform)

--- a/OnlTools/Jevp/StJevpBuilders/fstBuilder.h
+++ b/OnlTools/Jevp/StJevpBuilders/fstBuilder.h
@@ -963,7 +963,7 @@ class fstBuilder : public JevpBuilder {
 
   int sumHistogramsFilled;
   int numTb;
-
+  const int numTb_default = 3;
   JLatex* errorMsg;
 
   ClassDef(fstBuilder, 1);


### PR DESCRIPTION
Please bare with newbie to git...
1. Fix a bug in histogram index counting for frac vs APV index
2. Slightly adjusted the definition of fractions  (no impact when under 3 time bin)
3. Implement plotting range; add control variable

Changing time bin will not crash the online monitor. Only the plotting range needs to be adjusted. 

I figure it would be better to merge this commits to JevpProduction, and later you can merge what's already online to the main branch of star-sw.